### PR TITLE
Use yarn to publish

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -37,7 +37,7 @@ jobs:
           APP_VERSION: ${{ steps.vars.outputs.version }}
 
       - name: Publish
-        run: npm publish --access public
+        run: yarn publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
This one can understand `.npmignore` globs:

```
*
!/dist/**/*
!/package.json
!/CHANGELOG.md
!/README.md
```

npm published just `src/index.js`!