### PR TITLE
Add methods typing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,21 @@ const main = async () => {
 
 main().catch((e: Error) => console.error(e));
 ```
+
+Additionally, you can create client proxy and specify function signatures
+
+```ts
+import { WikiRpcClient, DokuwikiService, WikiRpcClient } from "@glen/wiki-rpc-client";
+
+// create client proxy with DokuwikiService service definitions
+const client = WikiRpcClient.create<DokuwikiService>(url);
+
+// the services can be combined as well:
+const client = WikiRpcClient.create<WikiService & DokuwikiService>(url);
+
+const dwVersion = await client["dokuwiki.getVersion"]();
+console.log(dwVersion);
+
+const data = await client["wiki.getPage"]("start");
+console.log(data);
+```

--- a/src/WikiRpcClient.ts
+++ b/src/WikiRpcClient.ts
@@ -14,6 +14,21 @@ export class WikiRpcClient {
     this.client = this.createClient(this.url, options);
   }
 
+  public static create<T>(
+    url: string,
+    options: Options = {},
+  ): T {
+    const client = new WikiRpcClient(url, options);
+
+    return new Proxy<WikiRpcClient>(client, client) as T;
+  }
+
+  public get(target: object, methodName: string) {
+    return (...params: string[]): any => {
+      return this.call(methodName, params);
+    };
+  }
+
   public async call<T extends XmlRpcValue>(methodName: string, params: XmlRpcValue[] = []): Promise<T> {
     return await this.client.methodCall(methodName, params) as T;
   }

--- a/src/WikiRpcClient.ts
+++ b/src/WikiRpcClient.ts
@@ -14,19 +14,19 @@ export class WikiRpcClient {
     this.client = this.createClient(this.url, options);
   }
 
-  public static create<T = WikiRpcClient>(
+  public static create<T>(
     url: string,
     options: Options = {},
   ): T {
     const client = new WikiRpcClient(url, options);
 
-    return new Proxy<T>(client, {
+    return new Proxy<WikiRpcClient>(client, {
       get(target: object, methodName: string) {
         return (...params: string[]): any => {
           return client.call(methodName, params);
         };
       },
-    });
+    }) as T;
   }
 
   public async call<T extends XmlRpcValue>(methodName: string, params: XmlRpcValue[] = []): Promise<T> {

--- a/src/WikiRpcClient.ts
+++ b/src/WikiRpcClient.ts
@@ -21,7 +21,7 @@ export class WikiRpcClient {
     const client = new WikiRpcClient(url, options);
 
     return new Proxy<WikiRpcClient>(client, {
-      get(target: object, methodName: string) {
+      get(target: never, methodName: string) {
         return (...params: string[]): any => {
           return client.call(methodName, params);
         };

--- a/src/WikiRpcClient.ts
+++ b/src/WikiRpcClient.ts
@@ -14,19 +14,19 @@ export class WikiRpcClient {
     this.client = this.createClient(this.url, options);
   }
 
-  public static create<T>(
+  public static create<T = WikiRpcClient>(
     url: string,
     options: Options = {},
   ): T {
     const client = new WikiRpcClient(url, options);
 
-    return new Proxy<WikiRpcClient>(client, client) as T;
-  }
-
-  public get(target: object, methodName: string) {
-    return (...params: string[]): any => {
-      return this.call(methodName, params);
-    };
+    return new Proxy<T>(client, {
+      get(target: object, methodName: string) {
+        return (...params: string[]): any => {
+          return client.call(methodName, params);
+        };
+      },
+    });
   }
 
   public async call<T extends XmlRpcValue>(methodName: string, params: XmlRpcValue[] = []): Promise<T> {


### PR DESCRIPTION
This allows to use TypeScript function signatures.


```ts
import { WikiRpcClient, DokuwikiService, WikiRpcClient } from "@glen/wiki-rpc-client";

// create client proxy with DokuwikiService service definitions
const client = WikiRpcClient.create<DokuwikiService>(url);

// the services can be combined as well:
const client = WikiRpcClient.create<WikiService & DokuwikiService>(url);

const data = await client["wiki.getPageVersion"]("start", 0);
console.log(data);

const dwVersion = await client["dokuwiki.getVersion"]();
console.log(dwVersion);
```